### PR TITLE
Фикс медхуда при реанимации дефибами

### DIFF
--- a/code/game/objects/items/weapons/defibrillator.dm
+++ b/code/game/objects/items/weapons/defibrillator.dm
@@ -120,5 +120,6 @@
 		returnable.tod = null
 		returnable.timeofdeath = 0
 		dead_mob_list -= returnable
+		update_health_hud()
 
 		return

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -440,8 +440,7 @@
 		if (C.legcuffed && !initial(C.legcuffed))
 			C.drop_from_inventory(C.legcuffed)
 		C.legcuffed = initial(C.legcuffed)
-	hud_updateflag |= 1 << HEALTH_HUD
-	hud_updateflag |= 1 << STATUS_HUD
+	update_health_hud()
 
 /mob/living/proc/rejuvenate()
 
@@ -497,10 +496,12 @@
 
 	// make the icons look correct
 	regenerate_icons()
+	update_health_hud()
+	return
 
+/mob/living/proc/update_health_hud()
 	hud_updateflag |= 1 << HEALTH_HUD
 	hud_updateflag |= 1 << STATUS_HUD
-	return
 
 /mob/living/proc/UpdateDamageIcon()
 	return


### PR DESCRIPTION
Теперь не надо тыкать анализатором, чтобы узнать сработали ли дефибы или
нет. Статус для медхуда обновляется во время оживления.